### PR TITLE
QEA-118: Added ability to compare element screenshots

### DIFF
--- a/gridium.gemspec
+++ b/gridium.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency "selenium-webdriver", "~> 2.50.0"
-  spec.add_runtime_dependency "oily_png", "~> 1.1", ">= 1.1.2"
+  spec.add_runtime_dependency "oily_png", "~> 1.2"
 
 end

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -247,14 +247,15 @@ class Element
   def compare_element_screenshot(base_image_path)
     #Returns TRUE if there are no differences, FALSE if there are
     begin
+      Log.debug("Loading Images for Comparison...")
       images = [
           ChunkyPNG::Image.from_file(base_image_path),
           ChunkyPNG::Image.from_file(@element_screenshot)
       ]
       #used to store image x,y diff
       diff = []
-
-      images.first.height.time do |y|
+      Log.debug("Comparing Images...")
+      images.first.height.times do |y|
         images.first.row(y).each_with_index do |pixel, x|
           diff << [x,y] unless pixel == images.last[x,y]
         end
@@ -267,8 +268,10 @@ class Element
       x, y = diff.map{|xy| xy[0]}, diff.map{|xy| xy[1]}
 
       if x.any? && y.any?
+        Log.debug("Differences Detected! Writing Diff Image...")
         name = self.name.gsub(' ', '_')
-        element_screenshot_path = File.join($current_run_dir, "#{name}__diff_#{Time.now.to_i}.png")
+        #timestamp = Time.now.strftime("%Y_%m_%d__%H_%M_%S")
+        element_screenshot_path = File.join($current_run_dir, "#{name}__diff_.png")
         images.last.rect(x.min, y.min, x.max, y.max, ChunkyPNG::Color(0,255,0))
         images.last.save(element_screenshot_path)
         return false

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.1.13"
+  VERSION = "0.1.14"
 end


### PR DESCRIPTION
Users can now use the element class to take a screenshot of an element and then compare that screenshot against a base line image.  This allows testing of look and feel changes that could be caused by css errors.

Designer think they know everything - until they break something.
