### PR TITLE
Page click enhancements

### DIFF
--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.1.16"
+  VERSION = "0.1.17"
 end

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -103,19 +103,36 @@ module Gridium
       Driver.driver.find_elements(by, locator).first
     end
 
-    def click_link(link_text)
-      Element.new("Clicking #{link_text} Link", :link_text, link_text).click
+    def click_on(text)
+      Element.new("Clicking #{text}", :xpath, "//*[text()='#{text}')]").click
     end
 
-    def click_button(button_name)
+    # Click the link on the page
+    # @param [String] link_text - Text of the link to click
+    # @param [Integer] link_index (optional) - With multiple links on the page with the same name, click on the specified link index
+    def click_link(link_text, link_index: nil)
+      if link_index
+        Element.new("Clicking #{link_text} Link (#{link_index})", :xpath, "(//a[contains(., '#{link_text}')])[#{link_index}]").click
+      else
+        Element.new("Clicking #{link_text} Link", :xpath, "//a[contains(., '#{link_text}')]").click
+      end
+    end
+
+    # Click the button on the page
+    # @param [String] link_text - Text of the link to click
+    # @param [Integer] link_index - With multiple links on the page with the same name, click on the specified link index (Defaults to first link found)
+    def click_button(button_name, button_index: nil)
       #The button maybe a link that looks like a button - we want to handle both
-      button = Element.new("A #{button_name} button", :xpath, "//button[contains(., '#{button_name}')]")
+      if button_index
+        button = Element.new("Clicking #{button_name} button (#{button_index})", :xpath, "(//button[contains(., '#{button_name}')])[#{button_index}]")
+      else
+        button = Element.new("Clicking #{button_name} button", :xpath, "//button[contains(., '#{button_name}')]")
+      end
       begin
         button.click
       rescue Exception
         Log.debug("Button not found - Attempting Link - speed up test by using click_link method if this works...")
-        link = Element.new("A #{button_name} link", :xpath, "//a[contains(., '#{button_name}')]")
-        link.click
+        click_link button_name, link_index: button_index
       end
     end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -86,13 +86,35 @@ describe Page do
       Driver.verify_url "https://sendgrid.com/pricing"
     end
 
-    it 'clicks a button' do
+    xit 'clicks a button' do
+      # no buttons to click
+    end
+
+    it 'clicks link index 1' do
       $verification_passes = 0
       Driver.visit "https://www.sendgrid.com"
       page = Page.new
 
-      page.click_button "node.js"
-      expect(Page.has_text?("// using SendGrid's Node.js Library")).to eql true
+      page.click_link "Contact Us", link_index: 1
+      Driver.verify_url "https://sendgrid.com/contact"
+    end
+
+    it 'clicks link index 2' do
+      $verification_passes = 0
+      Driver.visit "https://www.sendgrid.com"
+      page = Page.new
+
+      page.click_link "Contact Us", link_index: 2
+      Driver.verify_url "https://sendgrid.com/contact"
+    end
+
+    it 'clicks on any element in dom' do
+      $verification_passes = 0
+      Driver.visit "https://www.sendgrid.com"
+      page = Page.new
+
+      page.click_link "Contact Us", link_index: 2
+      Driver.verify_url "https://sendgrid.com/login"
     end
   end
 end


### PR DESCRIPTION
It would be ✨ to have the ability to use the `click_link` and `click_button` methods when there are multiple buttons/links on the page with the same text. Also adding a `click_on` method to click on any element within the dom.
- [x] Adding `click_on` method to page objects

`page_object.click_on(:xpath, "//div[@class='div javascripty button']")`
- [x] Support clicking multiple links/button with the same text

The `link_index` starts at `1`, similarly to referencing multiple `xpath` indexes. Here's how you would use it:

``` ruby
# Click link #1, verify something
page_object.click_link "Contact Us", link_index: 1

# Click link #2, verify something
page_object.click_link "Contact Us", link_index: 2
```

A similar method for buttons

``` ruby
# Click button #1, verify something
page_object.click_link "Contact Us", button_index: 1

# Click button #2, verify something
page_object.click_link "Contact Us", button_index: 2
```
