### PR TITLE
Update webdriver gemspec version dependency

### DIFF
--- a/gridium.gemspec
+++ b/gridium.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency "selenium-webdriver", "~> 2.50.0"
+  spec.add_runtime_dependency "selenium-webdriver"
   spec.add_runtime_dependency "oily_png", "~> 1.2"
 
 end

--- a/gridium.gemspec
+++ b/gridium.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency "selenium-webdriver"
+  spec.add_runtime_dependency "selenium-webdriver", ">= 2.50.0", "< 3"
   spec.add_runtime_dependency "oily_png", "~> 1.2"
-
 end

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.1.17"
+  VERSION = "0.1.18"
 end


### PR DESCRIPTION
The `gemspec` is hard-coding the `webdriver` version dependency to `2.50.0-2.50.x`. If I wanted to update my version of selenium for my project using `Gridium` to say [2.53.4](https://rubygems.org/gems/selenium-webdriver/versions/2.53.4), I am unable to because of this restriction. 
