### PR TITLE
Fix up staleness

### DIFF
--- a/lib/element_verification.rb
+++ b/lib/element_verification.rb
@@ -6,7 +6,7 @@ class Gridium::ElementVerification
   # @param [Integer] timeout
   # @param [Boolean] not_verification - Whether or not we are 'NOT' verifying something about the element
   #
-  def initialize(element, timeout, fail_test=false, element_should_exist=true)
+  def initialize(element, timeout, fail_test: false, element_should_exist: true)
     @element = element # Selement
     @timeout = timeout
     @should_exist = element_should_exist
@@ -14,7 +14,7 @@ class Gridium::ElementVerification
   end
 
   def not
-    ElementVerification.new(@element, @timeout, @fail_test, element_should_exist=false)
+    ElementVerification.new(@element, @timeout, @fail_test, element_should_exist: false)
   end
 
   def text(text)

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.1.20"
+  VERSION = "0.1.21"
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -297,16 +297,16 @@ describe Driver do
       end
     end
 
-    it 'calls #is_stale? when checking for elements on the page' do
+    it 'calls #stale? when checking for elements on the page' do
       page_element = create_new_element("Get Started Button", :css, '.billboard .btn-primary')
-      allow(page_element).to receive(:is_stale?).and_return(false)
+      allow(page_element).to receive(:stale?).and_return(false)
 
       test_driver.visit("http://www.sendgrid.com")
       page_element.click
       begin
         page_element.click
       rescue
-        expect(page_element).to have_received(:is_stale?).at_least(:once)
+        expect(page_element).to have_received(:stale?).at_least(:once)
       end
     end
   end


### PR DESCRIPTION
To make the `wait_until` and `verify` features more reliable. I've noticed that with `React` pages this functionality is not reliable when the DOM changes.