### PR TITLE
QEA-835: push screenshots to S3 with gridium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec-mocks'
+gem 'aws-sdk', '~> 2'

--- a/lib/gridium.rb
+++ b/lib/gridium.rb
@@ -7,6 +7,7 @@ require 'element'
 require 'element_extensions'
 require 'element_verification'
 require 'page'
+require 's3'
 
 module Gridium
   class << self
@@ -20,7 +21,7 @@ module Gridium
 
   class Config
     attr_accessor :report_dir, :browser_source, :target_environment, :browser, :url, :page_load_timeout, :element_timeout, :visible_elements_only, :log_level
-    attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure
+    attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure, :screenshots_to_s3
 
     def initialize
       @report_dir = Dir.home
@@ -35,6 +36,7 @@ module Gridium
       @highlight_verifications = false
       @highlight_duration = 0.100
       @screenshot_on_failure = false
+      @screenshots_to_s3 = false
     end
   end
 end

--- a/lib/gridium.rb
+++ b/lib/gridium.rb
@@ -21,7 +21,7 @@ module Gridium
 
   class Config
     attr_accessor :report_dir, :browser_source, :target_environment, :browser, :url, :page_load_timeout, :element_timeout, :visible_elements_only, :log_level
-    attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure, :screenshots_to_s3
+    attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure, :screenshots_to_s3, :project_name_for_s3, :subdirectory_name_for_s3
 
     def initialize
       @report_dir = Dir.home
@@ -37,6 +37,8 @@ module Gridium
       @highlight_duration = 0.100
       @screenshot_on_failure = false
       @screenshots_to_s3 = false
+      @project_name_for_s3 = 'gridium'
+      @subdirectory_name_for_s3 = '' #rely on GridiumS3 default
     end
   end
 end

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.1.21"
+  VERSION = "0.2.0"
 end

--- a/lib/log.rb
+++ b/lib/log.rb
@@ -86,6 +86,7 @@ module Gridium
         @@devices ||= []
         log.attach(device)
         @@devices << device
+        log.add(log.level, "device added: #{File.absolute_path(device)}")
       end
 
       def close
@@ -134,7 +135,6 @@ module Gridium
             "#{base_msg} X #{msg}\n"
           end
         end
-
         logger
       end # initialize_logger
     end # class << self

--- a/lib/s3.rb
+++ b/lib/s3.rb
@@ -1,0 +1,70 @@
+require 'aws-sdk'
+module Gridium
+
+
+    class GridiumS3
+
+        ACCESS_KEY_ID = ENV['S3_ACCESS_KEY_ID']
+        SECRET_ACCESS_KEY = ENV['S3_SECRET_ACCESS_KEY']
+        DEFAULT_REGION = ENV['S3_DEFAULT_REGION']
+        ROOT_BUCKET = ENV['S3_ROOT_BUCKET']
+        DELIMITER = "/"
+
+
+        def initialize(project_name, subdirectory_name='screenshots')
+            Log.debug("initializing GridiumS3 with #{project_name} and #{subdirectory_name}")
+            Aws.config.update({ credentials: Aws::Credentials.new(ACCESS_KEY_ID, SECRET_ACCESS_KEY) ,region: DEFAULT_REGION})
+            _validate_string(project_name)
+            _validate_string(subdirectory_name)
+            @project_name = _sanitize_string(project_name)
+            @subdirectory_name = _sanitize_string(subdirectory_name)
+            @bucket = Aws::S3::Resource.new().bucket(ROOT_BUCKET)
+        end
+
+        def save_file(absolute_path_of_file)
+            Log.debug("attempting to save #{absolute_path_of_file} to s3")
+            _validate_path(absolute_path_of_file)
+            file_name = File.basename(absolute_path_of_file)
+            destination_name = create_s3_name(file_name)
+            @bucket.object(destination_name).upload_file(absolute_path_of_file)
+            @bucket.object(destination_name).wait_until_exists
+            _verify_upload(destination_name, absolute_path_of_file)
+            # @bucket.object(s3_name).presigned_url(:get, expires_in: 3600) #uncomment this if public url ends up not working out OPREQ-83850
+            @bucket.object(destination_name).public_url
+        end
+
+        def create_s3_name(file_name)
+            _validate_string(file_name)
+            file_name = _sanitize_string(file_name)
+            joined_name = [@project_name, @subdirectory_name, file_name].join(DELIMITER)
+            joined_name
+        end
+
+        def _sanitize_string(input_string)
+            #remove left/right whitespace, split and join to collapse contiguous white space, replace whitespace and non-period special chars with underscore
+            input_string = input_string.strip().split.join(" ").gsub(/[^\w.]/i, '_') 
+            input_string
+        end
+
+        def _validate_string(input_string)
+            Log.debug("attempting to validate #{input_string} for use as a name") 
+            if input_string.empty? or input_string.strip().empty? then
+                raise(ArgumentError, "empty and/or whitespace file names are not wanted here.")
+            end
+        end
+
+        def _validate_path(path_to_file)
+            Log.debug("attmepting to validate #{path_to_file} as a legitimate path")
+            if not File.exist? path_to_file then
+                raise(ArgumentError, "this path doesn't resolve #{path_to_file}")
+            end
+        end
+
+        def _verify_upload(s3_name, local_absolute_path)
+            upload_size = @bucket.object(s3_name).content_length
+            local_size = File.size local_absolute_path
+            Log.debug("file upload verified: #{upload_size == local_size}. upload size is #{upload_size} and local size is #{local_size}")
+            upload_size == local_size            
+        end
+    end
+end

--- a/spec/s3_spec.rb
+++ b/spec/s3_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+require 'tmpdir'
+
+describe GridiumS3 do
+  let(:gridium_config) { Gridium.config }
+  let(:project_name) { "spec" }
+  let(:subdirectory_name) {"child_of_spec"}
+  let(:empty_name) { "" }
+  let(:whitespace_name) { "\t\r\n " } #tab, carriage return, newline, space
+  let(:s3) { Gridium::GridiumS3.new(project_name, subdirectory_name) }
+  let(:logger) { Log }
+
+  describe 's3 instantiation' do
+    it 'will fail without a project name' do
+        no_arg_call = lambda {Gridium::GridiumS3.new}
+        expect(&no_arg_call).to raise_error(ArgumentError)
+    end
+
+    it 'will succeed with a project name and without a subdirectory name' do
+        s3 = Gridium::GridiumS3.new(project_name)
+    end
+
+    it 'will succeed with both a project name and a subdirectory name' do
+        s3 = Gridium::GridiumS3.new(project_name, subdirectory_name)
+    end
+  end
+  describe 's3 configuration' do
+
+      let(:s3_access_key_id) {ENV['S3_ACCESS_KEY_ID']}
+      let(:s3_secret_access_key) {ENV['S3_SECRET_ACCESS_KEY']}
+      let(:s3_default_region) {ENV['S3_DEFAULT_REGION']}
+      let(:s3_root_bucket) {ENV['S3_ROOT_BUCKET']}
+      let(:s3_shibboleth) {ENV['S3_SHIBBOLETH']}
+
+    it 'requires that the S3_ACCESS_KEY_ID environment variable exists' do
+        expect(s3_access_key_id).not_to be_nil
+    end
+
+    it 'requires that the S3_SECRET_ACCESS_KEY environment variable exists' do
+        expect(s3_secret_access_key).not_to be_nil
+    end
+    it 'requires that the S3_DEFAULT_REGION environment variable exists' do
+        expect(s3_default_region).not_to be_nil
+    end
+    it 'requires that the S3_ROOT_BUCKET environment variable exists' do
+        expect(s3_root_bucket).not_to be_nil
+    end
+
+    it 'requires that the S3_SHIBBOLETH environment variable does not exist' do
+        expect(s3_shibboleth).to be_nil
+    end
+
+  describe 's3 file naming'do
+      let(:file_name) {"temp.txt"}
+    
+    it 'will fail without a file name' do
+        no_arg_call = lambda {s3.create_s3_name}
+        expect(&no_arg_call).to raise_error(ArgumentError)
+    end
+
+    it 'will fail with an empty file name' do
+        empty_string_call = lambda {s3.create_s3_name empty_name}
+        expect(&empty_string_call).to raise_error(ArgumentError)
+    end
+
+    it 'will fail with a white space file name' do
+        whitespace_string_call = lambda {s3.create_s3_name whitespace_name} 
+        expect(&whitespace_string_call).to raise_error(ArgumentError)
+    end
+
+    it 'will sanitize whitespace in project name', :focus => true  do        
+        whitespaced_project_name = "\t\r\n spec \t\r\n project \t\r\n "
+        sanitized_project_name = "spec_project"
+        s3 = Gridium::GridiumS3.new(whitespaced_project_name, subdirectory_name)
+        expected_s3_name = sanitized_project_name + "/" + subdirectory_name + "/" + file_name
+        actual_s3_name = s3.create_s3_name(file_name)
+        expect(actual_s3_name).to eq expected_s3_name
+    end
+
+    it 'will sanitize whitespace in subdirectory name', :focus => true  do
+        whitespaced_subdirectory_name = "\t\r\n desc \t\r\n of \t\r\n spec \t\r\n "
+        sanitized_subdirectory_name = "desc_of_spec"
+        s3 = Gridium::GridiumS3.new(project_name, whitespaced_subdirectory_name)
+        expected_s3_name = project_name + "/" + sanitized_subdirectory_name + "/" + file_name
+        actual_s3_name = s3.create_s3_name(file_name)
+        expect(actual_s3_name).to eq expected_s3_name
+    end
+
+    it 'will sanitize whitespace in file name', :focus => true  do
+        whitespaced_file_name = "\t\r\n temp \t\r\n name.txt \t\r\n "
+        sanitized_file_name = "temp_name.txt"
+        expected_s3_name = project_name + "/" + subdirectory_name + "/" + sanitized_file_name
+        actual_s3_name = s3.create_s3_name(whitespaced_file_name)
+        expect(actual_s3_name).to eq expected_s3_name
+    end
+
+    it 'will default the subdirectory name to screenshots' do
+        #TODO implement this
+    end
+
+  end
+   describe 's3 file saving' do
+
+     before :all do
+         #create a temp folder in the systems tmp directory
+         tmp = Dir.tmpdir()
+         temp_subdirectory = "gridium_#{Time.now.to_i}"
+         @temp_path = File.join(tmp, temp_subdirectory)
+         Dir.mkdir(@temp_path)
+         @temp_files = []
+     end
+
+     before :each do
+         #create temp files with token contents
+         @file_name = "temp_#{Time.now.to_i}.txt"
+         @full_path = File.join(@temp_path, @file_name)
+         File.open(@full_path, File::WRONLY | File::APPEND | File::CREAT) do |temp_file| 
+             temp_file.write("hello world112233")
+         end
+         @temp_files.push @full_path
+     end
+
+     after :all do
+         #delete the temp files
+         @temp_files.each do |temp_file| 
+            if File.exist? temp_file then
+                File.delete temp_file
+                Log.debug("deleted #{temp_file} during teardown")
+            end
+         end
+         #delete the temp folder
+         Dir.delete(@temp_path) 
+         Log.debug("deleted #{@temp_path} during teardown")
+     end
+
+     it 'succeeds with a local file'  do
+         s3.save_file(@full_path)
+    end
+    it 'fails if the file doesn\'t exist' do
+        non_existant_file = "nuke_me_#{Time.now.to_i}.txt"
+        path_to_non_existant_file = File.join(@temp_path, non_existant_file)
+        if File.exist? path_to_non_existant_file then
+            File.delete path_to_non_existant_file
+        end
+        bad_file_call = lambda {s3.save_file(path_to_non_existant_file)}
+        expect(bad_file_call).to raise_error ArgumentError
+    end 
+    it 'fails if the file path is invalid' do
+        non_existant_path = File.join(@temp_path, "#{Time.now.to_i}", @file_name)
+        bad_path_call = lambda {s3.save_file(non_existant_path)}
+        expect(bad_path_call).to raise_error ArgumentError
+    end 
+ end
+end

--- a/spec/s3_spec.rb
+++ b/spec/s3_spec.rb
@@ -30,7 +30,6 @@ describe GridiumS3 do
       let(:s3_secret_access_key) {ENV['S3_SECRET_ACCESS_KEY']}
       let(:s3_default_region) {ENV['S3_DEFAULT_REGION']}
       let(:s3_root_bucket) {ENV['S3_ROOT_BUCKET']}
-      let(:s3_shibboleth) {ENV['S3_SHIBBOLETH']}
 
     it 'requires that the S3_ACCESS_KEY_ID environment variable exists' do
         expect(s3_access_key_id).not_to be_nil
@@ -45,10 +44,8 @@ describe GridiumS3 do
     it 'requires that the S3_ROOT_BUCKET environment variable exists' do
         expect(s3_root_bucket).not_to be_nil
     end
+  end
 
-    it 'requires that the S3_SHIBBOLETH environment variable does not exist' do
-        expect(s3_shibboleth).to be_nil
-    end
 
   describe 's3 file naming'do
       let(:file_name) {"temp.txt"}
@@ -95,7 +92,11 @@ describe GridiumS3 do
     end
 
     it 'will default the subdirectory name to screenshots' do
-        #TODO implement this
+      default_subdir_name = 'screenshots'
+      sanitized_file_name = "temp_name.txt"
+      s3 = Gridium::GridiumS3.new(project_name)
+      actual_s3_name = s3.create_s3_name(sanitized_file_name)
+      expect(actual_s3_name).to include default_subdir_name
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'page_objects/google_home'
 
 # Setup any custom configuration for the Corundum framework
 Gridium.configure do |config|
+  # config.report_dir = File.expand_path File.dirname(__FILE__)
   config.report_dir = Dir.home.to_s + "/desktop"
   config.browser_source = :local
   config.target_environment = "localhost"
@@ -18,4 +19,32 @@ Gridium.configure do |config|
   config.highlight_verifications = true
   config.highlight_duration = 0.100
   config.screenshot_on_failure = false
+  config.screenshots_to_s3 = true
 end
+
+RSpec.configure do |config|
+  include Gridium
+    config.before :all do
+      # Create the test report root directory
+      report_root_dir = File.expand_path(File.join(Gridium.config.report_dir, 'spec_reports'))
+      Dir.mkdir(report_root_dir) if not File.exist?(report_root_dir)
+
+      # Create the sub-directory for the test suite run
+      current_run_report_dir = File.join(report_root_dir, "spec_results__" + DateTime.now.strftime("%m_%d_%Y__%H_%M_%S"))
+      $current_run_dir = current_run_report_dir
+      Dir.mkdir(current_run_report_dir)
+      puts "logging to:  #{current_run_report_dir}"
+
+      # Add the output log file for the rspec test run to the logger
+      Log.add_device(File.open(File.join(current_run_report_dir, "spec_logging_output.log"), File::WRONLY | File::APPEND | File::CREAT))
+
+      # Reset Suite statistics
+      $verifications_total = 0
+      $warnings_total = 0
+      $errors_total = 0
+
+      #Setup Gridium Spec Data
+      SpecData.load_suite_state
+      SpecData.load_spec_state
+    end #end before:all
+end #end Rspec.config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,6 @@ end
 RSpec.configure do |config|
   include Gridium
     config.before :all do
-      project_name_for_s3 = 'gridium'
       # Create the test report root directory
       report_root_dir = File.expand_path(File.join(Gridium.config.report_dir, 'spec_reports'))
       Dir.mkdir(report_root_dir) if not File.exist?(report_root_dir)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,11 +20,14 @@ Gridium.configure do |config|
   config.highlight_duration = 0.100
   config.screenshot_on_failure = false
   config.screenshots_to_s3 = true
+  config.project_name_for_s3 = 'gridium'
+  config.subdirectory_name_for_s3 = DateTime.now.strftime("%m_%d_%Y__%H_%M_%S")
 end
 
 RSpec.configure do |config|
   include Gridium
     config.before :all do
+      project_name_for_s3 = 'gridium'
       # Create the test report root directory
       report_root_dir = File.expand_path(File.join(Gridium.config.report_dir, 'spec_reports'))
       Dir.mkdir(report_root_dir) if not File.exist?(report_root_dir)


### PR DESCRIPTION
This PR contains the work for allowing screenshots to be saved in S3.
It requires that environment variables be set on the host that contain the credentials.

New unit tests are s3_spec.rb and a new block in driver_spec.rb (S3 Support)

Run these tests via

```
rspec ./spec/driver_spec.rb -e "S3 support"
rspec ./spec/s3_spec.rb
```

The configuration is handled in the spec_helper.rb file. Specifically these lines, which demonstrates how to integrate these changes into another repo:
```
config.screenshots_to_s3 = true
config.project_name_for_s3 = 'gridium'
config.subdirectory_name_for_s3 = DateTime.now.strftime("%m_%d_%Y__%H_%M_%S")
```

I added the rspec config stuff to the spec_helper to fix an unrelated logging bug that was bothering me; now when adding a device that event is logged and should appear in the device itself. This resolves the 0kb log file issue.