### PR TITLE
QEA-835: I think I need this change so stui won't need aws-sdk gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec-mocks'
-gem 'aws-sdk', '~> 2'

--- a/gridium.gemspec
+++ b/gridium.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "selenium-webdriver", ">= 2.50.0", "< 3"
   spec.add_runtime_dependency "oily_png", "~> 1.2"
+  spec.add_runtime_dependency 'aws-sdk', '~> 2'
 end

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
I think I didn't set up the aws-sdk as a proper dependency. Downstream consumers would give errors when trying to enable the S3 functionality. I think this change resolves the issue