### PR TITLE
Add mouse_over and on_blur element extensions

### DIFF
--- a/lib/element.rb
+++ b/lib/element.rb
@@ -151,12 +151,33 @@ class Element
     end
   end
 
+  # Raw webdriver mouse over
+  def mouse_over
+    Log.debug("Triggering mouse over for (#{self.to_s})...")
+    if element.enabled?
+      $verification_passes += 1
+      ElementExtensions.mouse_over(self)
+    else
+      Log.error('Cannot mouse over.  Element is not present.')
+    end
+  end
+
   def scroll_into_view
     if element.enabled?
       $verification_passes += 1
       ElementExtensions.scroll_to(self)
     else
       Log.error('Cannot scroll element into view.  Element is not present.')
+    end
+  end
+
+  def trigger_onblur
+    Log.debug("Triggering onblur for (#{self.to_s})...")
+    if element.enabled?
+      $verification_passes += 1
+      ElementExtensions.trigger_onblur(self)
+    else
+      Log.error('Cannot trigger onblur.  Element is not present.')
     end
   end
 

--- a/lib/element_extensions.rb
+++ b/lib/element_extensions.rb
@@ -27,4 +27,12 @@ class Gridium::ElementExtensions
     Driver.execute_script("var evObj = document.createEvent('MouseEvents'); evObj.initMouseEvent(\"mouseout\",true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null); arguments[0].dispatchEvent(evObj);", element.element)
     sleep 1
   end
+
+  def self.mouse_over(element)
+    Driver.driver.mouse.move_to(element.element)
+  end
+
+  def self.trigger_onblur(element)
+    Driver.execute_script("arguments[0].focus(); arguments[0].blur(); return true", element.element)
+  end
 end

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Adding some useful element extensions
- [x] Some javascripty stuff does not trigger `onblur` events. 
- [x] Sometimes the javascript `hover_over` does not work. Add in an additional `mouse_over` extension that uses webdriver.