### PR TITLE
QEA-1127: Fix Gridium TestRail Integration

### DIFF
--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/lib/testrail.rb
+++ b/lib/testrail.rb
@@ -20,6 +20,8 @@ module Gridium
         @user = ENV['GRIDIUM_TR_USER'].empty? || ENV['GRIDIUM_TR_USER'].nil? ? ENV_ERROR : ENV['GRIDIUM_TR_USER']
         @password = ENV['GRIDIUM_TR_PW'].empty? || ENV['GRIDIUM_TR_PW'].nil? ? ENV_ERROR : ENV['GRIDIUM_TR_PW']
         @pid = ENV['GRIDIUM_TR_PID'].empty? || ENV['GRIDIUM_TR_PID'].nil? ? ENV_ERROR : ENV['GRIDIUM_TR_PID']
+				@testcase_ids = Array.new
+				@testcase_infos = Array.new
       end
 		end
 
@@ -37,44 +39,48 @@ module Gridium
       end
     end
 
-    def close_run
-      if Gridium.config.testrail
-        Log.debug("[GRIDIUM::TestRail] Closing RunID: #{@runid}")
-        unless @runid.nil?
-          r = _send_request('POST', "close_run/#{@runid}", nil)
-        end
-      end
-    end
+		def add_case(rspec_test)
+			if Gridium.config.testrail
+				Log.debug("[GRIDIUM::TestRail] Adding to list of TestRail Cases...")
+				if rspec_test.nil? then
+					Log.error("[GRIDIUM::TestRail] No test added to results. Turn of Gridium.config.testrail\n")
+				end
+				if rspec_test.exception
+					status = FAILED
+					message = rspec_test.exception.message
+				else
+					status = PASSED
+					message = 'Test Passed.'
+				end
+				test_info = {:trid => rspec_test.metadata[:testrail_id], :status_id => status, :message => message}
+				@testcase_infos.push(test_info)
+				@testcase_ids.push(test_info[:trid])
+			end
+		end
 
-    def add_case(rspec_test)
-      if Gridium.config.testrail
-        Log.debug("[GRIDIUM::TestRail] Adding case: #{rspec_test} for RunID: #{@runid}")
-        if rspec_test.nil? then
-          raise(ArgumentError, "No test data was passed in.")
-        end
-        unless @runid.nil?
-          r = _send_request('POST', "update_run/#{@runid}", {:case_ids => [rspec_test.metadata[:testrail_id]]})
-          if rspec_test.exception
-            status = FAILED
-            message = rspec_test.exception.message
-          else
-            status = PASSED
-            message = ''
-          end
-          r = _send_request(
-            'POST',
-            "add_result_for_case/#{@runid}/#{rspec_test.metadata[:testrail_id]}",
-            status_id: status,
-            comment: message
-          )
-        end
-      end
-    end
-
+		def close_run
+			if Gridium.config.testrail
+				Log.debug("[GRIDIUM::TestRail] Closing test runid: #{@runid}\n")
+				unless @runid.nil?
+					r = _send_request('POST', "update_run/#{@runid}", {:case_ids => @testcase_ids})
+					@testcase_infos.each do |tc|
+						r = _send_request(
+							'POST',
+							"add_result_for_case/#{@runid}/#{tc[:trid]}",
+							status_id: tc[:status_id],
+							comment: tc[:message]
+							)
+							sleep(0.25)
+					end
+					r = _send_request('POST', "close_run/#{@runid}", nil)
+				end
+			end
+		end
 
     private
 		def _send_request(method, uri, data)
 			url = URI.parse(@url + uri)
+			Log.debug("[GRIDIUM::TestRail] Method: #{method} URL:#{uri} Data:#{data}")
 			if method == 'POST'
 				request = Net::HTTP::Post.new(url.path + '?' + url.query)
 				request.body = JSON.dump(data)
@@ -90,7 +96,6 @@ module Gridium
 				conn.verify_mode = OpenSSL::SSL::VERIFY_NONE
 			end
 			response = conn.request(request)
-
 			if response.body && !response.body.empty?
 				result = JSON.parse(response.body)
 			else
@@ -98,11 +103,13 @@ module Gridium
 			end
 
 			if response.code != '200'
+
 				if result && result.key?('error')
 					error = '"' + result['error'] + '"'
 				else
 					error = 'No additional error message received'
 				end
+				Log.debug("[GRIDIUM::TestRail] Error with request: #{error}")
 				raise APIError.new('TestRail API returned HTTP %s (%s)' %
 					[response.code, error])
 			end


### PR DESCRIPTION
Gridium was not updating TestRail properly.  When adding tests to TestRail, the gem could no longer add tests to the run and results at the same time.  The API changed in such a way that the gem needs to add all the tests and results in one batch. 
